### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ chromadb
 tiktoken
 faiss-cpu
 wikipedia
+transformers


### PR DESCRIPTION
I was getting this Error while calling `chain.run(docs)`
ValueError: Could not import transformers python package. This is needed in order to calculate get_num_tokens. Please install it with `pip install transformers`.
